### PR TITLE
Feature: add option keepDefaultRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ Use your own `router.js` to handle your routes into your [Nuxt.js](https://nuxtj
 {
   modules: [
     '@nuxtjs/router'
- ]
+  ]
+}
+```
+
+or
+
+```js
+{
+  modules: [
+    ['@nuxtjs/router', { keepDefaultRouter: true }]
+  ]
 }
 ```
 
@@ -69,6 +79,27 @@ export function createRouter() {
       }
     ]
   })
+}
+```
+
+### Accessing default router
+
+If you use the module with `{ keepDefaultRouter: true }`, you can access the default router:
+
+```js
+import { createRouter as createDefaultRouter } from './defaultRouter'
+
+export function createRouter(ssrContext) {
+  const defaultRouter = createDefaultRouter(ssrContext)
+  return new Router({
+    ...defaultRouter.options,
+    routes: fixRoutes(defaultRouter.options.routes)
+  })
+}
+
+function fixRoutes(defaultRoutes) {
+  // default routes that come from `pages/`
+  return defaultRoutes.filter(...).map(...)
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,28 @@
 import { resolve } from 'path'
 import { existsSync } from 'fs'
 
-export default function () {
+export default function (options) {
+  const defaults = {
+    keepDefaultRouter: false
+  }
+  options = Object.assign({}, defaults, options)
+
   const routerPath = resolve(this.options.srcDir, 'router.js')
 
   // Check if router.js is defined
   if (!existsSync(routerPath)) throw new Error('[nuxt-router-module] Please create a router.js file in your source folder.')
 
-  // Disable parsing `pages/`
-  this.nuxt.options.build.createRoutes = () => {
-    return []
+  if (options.keepDefaultRouter) {
+    // Put default router as .nuxt/defaultRouter.js
+    this.addTemplate({
+      fileName: 'defaultRouter.js',
+      src: require.resolve('nuxt/lib/app/router')
+    })
+  } else {
+    // Disable parsing `pages/`
+    this.nuxt.options.build.createRoutes = () => {
+      return []
+    }
   }
 
   // Add ${srcDir}/router.js as the main template for routing

--- a/test/fixture/keepDefaultRouter/nuxt.config.js
+++ b/test/fixture/keepDefaultRouter/nuxt.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  srcDir: __dirname,
+  dev: false,
+  modules: [['~/../..', { keepDefaultRouter: true }]]
+}

--- a/test/fixture/keepDefaultRouter/pages/foo.vue
+++ b/test/fixture/keepDefaultRouter/pages/foo.vue
@@ -1,0 +1,3 @@
+<template>
+<div>Hello page</div>
+</template>

--- a/test/fixture/keepDefaultRouter/router.js
+++ b/test/fixture/keepDefaultRouter/router.js
@@ -1,0 +1,18 @@
+import Router from 'vue-router'
+
+import { createRouter as createDefaultRouter } from './defaultRouter'
+
+export function createRouter (ssrContext) {
+  const defaultRouter = createDefaultRouter(ssrContext)
+  return new Router({
+    ...defaultRouter.options,
+    routes: (defaultRoutes => {
+      return defaultRoutes.map(route => {
+        return {
+          ...route,
+          path: '/some' + route.path
+        }
+      })
+    })(defaultRouter.options.routes)
+  })
+}

--- a/test/keepDefaultRouter.test.js
+++ b/test/keepDefaultRouter.test.js
@@ -1,0 +1,32 @@
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000
+process.env.PORT = process.env.PORT || 4444
+process.env.NODE_ENV = 'production'
+
+const { Nuxt, Builder } = require('nuxt')
+const request = require('request-promise-native')
+
+const config = require('./fixture/keepDefaultRouter/nuxt.config')
+
+const url = path => `http://localhost:${process.env.PORT}${path}`
+const get = path => request(url(path))
+
+describe('Module', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    // Build a fresh nuxt
+    nuxt = new Nuxt(config)
+    await new Builder(nuxt).build()
+    await nuxt.listen(process.env.PORT)
+  })
+
+  afterAll(async () => {
+    // Close all opened resources
+    await nuxt.close()
+  })
+
+  test('render', async () => {
+    let html = await get('/some/foo')
+    expect(html).toContain('Hello page')
+  })
+})


### PR DESCRIPTION
In my project, I want to keep `pages/` directory but I want to customize routes per request.

My real-life use case is:

<https://myproject.com/***> should come from `pages/*.vue`
<https://***.myproject.com/***> (subdomains) should come from `pages/app/*.vue` (entirely different set of pages)

Unfortunately, Nuxt.js [lib/app/index.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/app/index.js#L47) and [lib/app/router.js](https://github.com/nuxt/nuxt.js/blob/dev/lib/app/router.js#L96) don't provide any suitable hooks.

If I use `@nuxtjs/router` with fully custom routes, I lose the `pages/` directory parser, `scrollBehavior` and possibly other goodies. I am happy to use the default routes generator, I just want to have some post-processing.

This PR is an attempt to solve the problem. How it works: if `@nuxtjs/router` module is created with `{ keepDefaultRouter: true }` (false by default), the default router will not be thrown away but kept in `.nuxt/defaultRouter.js`. Custom `router.js` may then import it and reuse its options when creating a new Router instance, then amend, filter or modify routes or other router options. I included a simple unit test that shows how it may work (it's more complicated in real life, of course).

---

This solution is surely not perfect. Instantiating default router simply to access its options is suboptimal (it would rather be better if Nuxt's `lib/app/router.js` exported not only `createRouter` but also `routerOptions`). Filtering and modifying rules *per request* is also suboptimal, in my case I only need two static subsets and it would be great if I could emit them with the builder rather than do that in runtime for each request. But at least it's something.