### PR TITLE
feat(module): import router on plugin, inject defaultRouter if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,19 @@ If you are using SPA mode, add an index `/` route to `generate` section of `nuxt
 ## Options
 
 ### `path`
+
 - Default: `srcDir`
 
 Location of you route file.
 
 ### `fileName`
+
 - Default: `router.js`
 
 Name of you route file.
 
 ### `keepDefaultRouter`
+
 - Default: `false`
 
 Can access the default router.
@@ -106,9 +109,7 @@ export function createRouter() {
 If you use the module with `{ keepDefaultRouter: true }`, you can access the default router:
 
 ```js
-import { createRouter as createDefaultRouter } from './defaultRouter'
-
-export function createRouter(ssrContext) {
+export function createRouter(ssrContext, createDefaultRouter) {
   const defaultRouter = createDefaultRouter(ssrContext)
   return new Router({
     ...defaultRouter.options,

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,28 +23,6 @@ function routerModule(moduleOptions) {
     return consola.warn(`No \`${options.fileName}\` file found in \`${options.path}\`.`)
   }
 
-  if (options.keepDefaultRouter) {
-    // Put default router as .nuxt/defaultRouter.js
-    let defaultRouter
-
-    try {
-      defaultRouter = require.resolve('@nuxt/vue-app/template/router')
-    } catch (err) {
-      /* istanbul ignore next */
-      defaultRouter = require.resolve('nuxt/lib/app/router')
-    }
-
-    this.addTemplate({
-      fileName: 'defaultRouter.js',
-      src: defaultRouter
-    })
-  } else {
-    // Disable parsing `pages/`
-    this.nuxt.options.build.createRoutes = () => {
-      return []
-    }
-  }
-
   // Add plugin to import router file path as the main template for routing
   this.addPlugin({
     src: resolve(__dirname, 'plugin.js'),
@@ -53,6 +31,30 @@ function routerModule(moduleOptions) {
       routerFilePath: relative(this.options.buildDir, routerFilePath).replace(/\/+/g, '/'),
       keepDefaultRouter: options.keepDefaultRouter
     }
+  })
+
+  // Disable parsing `pages/`
+  if (!options.keepDefaultRouter) {
+    this.nuxt.options.build.createRoutes = () => {
+      return []
+    }
+
+    return
+  }
+
+  // Put default router as .nuxt/defaultRouter.js
+  let defaultRouter
+
+  try {
+    defaultRouter = require.resolve('@nuxt/vue-app/template/router')
+  } catch (err) {
+    /* istanbul ignore next */
+    defaultRouter = require.resolve('nuxt/lib/app/router')
+  }
+
+  this.addTemplate({
+    fileName: 'defaultRouter.js',
+    src: defaultRouter
   })
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { relative, resolve } = require('path')
 const { existsSync } = require('fs')
 const consola = require('consola')
 
@@ -23,34 +23,36 @@ function routerModule(moduleOptions) {
     return consola.warn(`No \`${options.fileName}\` file found in \`${options.path}\`.`)
   }
 
-  // Add router file path as the main template for routing
-  this.addTemplate({
-    fileName: 'router.js',
-    src: routerFilePath
-  })
+  if (options.keepDefaultRouter) {
+    // Put default router as .nuxt/defaultRouter.js
+    let defaultRouter
 
-  // Disable parsing `pages/`
-  if (!options.keepDefaultRouter) {
+    try {
+      defaultRouter = require.resolve('@nuxt/vue-app/template/router')
+    } catch (err) {
+      /* istanbul ignore next */
+      defaultRouter = require.resolve('nuxt/lib/app/router')
+    }
+
+    this.addTemplate({
+      fileName: 'defaultRouter.js',
+      src: defaultRouter
+    })
+  } else {
+    // Disable parsing `pages/`
     this.nuxt.options.build.createRoutes = () => {
       return []
     }
-
-    return
   }
 
-  // Put default router as .nuxt/defaultRouter.js
-  let defaultRouter
-
-  try {
-    defaultRouter = require.resolve('@nuxt/vue-app/template/router')
-  } catch (err) {
-    /* istanbul ignore next */
-    defaultRouter = require.resolve('nuxt/lib/app/router')
-  }
-
-  this.addTemplate({
-    fileName: 'defaultRouter.js',
-    src: defaultRouter
+  // Add plugin to import router file path as the main template for routing
+  this.addPlugin({
+    src: resolve(__dirname, 'plugin.js'),
+    fileName: 'router.js',
+    options: {
+      routerFilePath: relative(this.options.buildDir, routerFilePath).replace(/\/+/g, '/'),
+      keepDefaultRouter: options.keepDefaultRouter
+    }
   })
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,0 +1,10 @@
+import { createRouter as customCreateRouter } from '<%= options.routerFilePath %>'
+<% if (options.keepDefaultRouter) { %>
+import { createRouter as createDefaultRouter } from './defaultRouter'
+<% } else { %>
+const createDefaultRouter = null
+<% } %>
+
+export function createRouter(ssrContext) {
+  return customCreateRouter(ssrContext, createDefaultRouter)
+}

--- a/test/fixture/keepDefaultRouter/router.js
+++ b/test/fixture/keepDefaultRouter/router.js
@@ -1,8 +1,6 @@
 import Router from 'vue-router'
 
-import { createRouter as createDefaultRouter } from './defaultRouter'
-
-export function createRouter(ssrContext) {
+export function createRouter(ssrContext, createDefaultRouter) {
   const defaultRouter = createDefaultRouter(ssrContext)
   return new Router({
     ...defaultRouter.options,


### PR DESCRIPTION
- Add plugin to import router file (ESLint works now)
- Inject `createDefaultRouter` in `createRouter` if `keepDefaultRouter` enabled

Resolves #17 