### PR TITLE
fix: keepDefaultRouter option broken in nuxt 2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ If you use the module with `{ keepDefaultRouter: true }`, you can access the def
 
 :warning: If you are using Nuxt `< 2.9.0`, the parameter `routerOptions` is not available.
 
+:warning: If you are using Nuxt `< 2.15.0`, the parameter `config` is not available.
+
 ```js
-export function createRouter(ssrContext, createDefaultRouter, routerOptions) {
-  const options = routerOptions ? routerOptions : createDefaultRouter(ssrContext).options
+export function createRouter(ssrContext, createDefaultRouter, routerOptions, config) {
+  const options = routerOptions ? routerOptions : createDefaultRouter(ssrContext, config).options
 
   return new Router({
     ...options,

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,6 +7,6 @@ const createDefaultRouter = null
 const routerOptions = null
 <% } %>
 
-export function createRouter(ssrContext) {
-  return customCreateRouter(ssrContext, createDefaultRouter, routerOptions)
+export function createRouter(ssrContext, config) {
+  return customCreateRouter(ssrContext, createDefaultRouter, routerOptions, config)
 }


### PR DESCRIPTION
Resolve #91 